### PR TITLE
Add SetFlipVerticallyOnLoad method

### DIFF
--- a/libstbi/src/stbi.cpp
+++ b/libstbi/src/stbi.cpp
@@ -46,6 +46,10 @@ extern "C" {
         return stbi_load_from_memory(data, (int)len, w, h, nChannels, nDesiredChannels);
     }
 
+    EXPORT void SetFlipVerticallyOnLoad(int flag_true_if_should_flip) {
+        stbi_set_flip_vertically_on_load(flag_true_if_should_flip);
+    }
+
     EXPORT void Free(unsigned char* pixels) {
         stbi_image_free(pixels);
     }

--- a/libstbi/src/stbi.cpp
+++ b/libstbi/src/stbi.cpp
@@ -46,8 +46,8 @@ extern "C" {
         return stbi_load_from_memory(data, (int)len, w, h, nChannels, nDesiredChannels);
     }
 
-    EXPORT void SetFlipVerticallyOnLoad(int flag_true_if_should_flip) {
-        stbi_set_flip_vertically_on_load(flag_true_if_should_flip);
+    EXPORT void SetFlipVerticallyOnLoad(int shouldFlip) {
+        stbi_set_flip_vertically_on_load(shouldFlip);
     }
 
     EXPORT void Free(unsigned char* pixels) {

--- a/stbi-sharp.cs
+++ b/stbi-sharp.cs
@@ -205,7 +205,8 @@ namespace StbiSharp
         unsafe public static extern byte* LoadFromMemory(byte* data, long len, out int width, out int height, out int numChannels, int desiredNumChannels);
 
         /// <summary>
-        /// flip the image vertically, so the first pixel in the output array is the bottom left
+        /// Flip the image vertically, so the first pixel in the output array is the bottom left.
+
         /// </summary>
         /// <param name="flagTrueIfShouldFlip">Flag set if should flip vertically on load.
         [DllImport("stbi")]

--- a/stbi-sharp.cs
+++ b/stbi-sharp.cs
@@ -204,8 +204,12 @@ namespace StbiSharp
         [DllImport("stbi")]
         unsafe public static extern byte* LoadFromMemory(byte* data, long len, out int width, out int height, out int numChannels, int desiredNumChannels);
 
+        /// <summary>
+        /// flip the image vertically, so the first pixel in the output array is the bottom left
+        /// </summary>
+        /// <param name="flagTrueIfShouldFlip">Flag set if should flip vertically on load.
         [DllImport("stbi")]
-        unsafe public static extern void StbiSetFlipVerticallyOnLoad(bool flagTrueIfShouldFlip);
+        unsafe public static extern void SetFlipVerticallyOnLoad(bool flagTrueIfShouldFlip);
 
         /// <summary>
         /// Frees memory of an image that has previously been loaded by <see cref="LoadFromMemory"/>. Only
@@ -272,7 +276,5 @@ namespace StbiSharp
         /// been allocated to store the image data.</returns>
         public static StbiImage LoadFromMemory(MemoryStream data, int desiredNumChannels)
             => LoadFromMemory(data.GetBuffer(), desiredNumChannels);
-
-        public static void SetFlipVerticallyOnLoad(bool flagTrueIfShouldFlip) => StbiSetFlipVerticallyOnLoad(flagTrueIfShouldFlip);
     }
 }

--- a/stbi-sharp.cs
+++ b/stbi-sharp.cs
@@ -113,9 +113,9 @@ namespace StbiSharp
         unsafe public static void LoadFromMemoryIntoBuffer(ReadOnlySpan<byte> data, int desiredNumChannels, Span<byte> dst)
         {
             fixed (byte* address = data)
-                fixed (byte* dstAddress = dst)
-                    if (!LoadFromMemoryIntoBuffer(address, data.Length, desiredNumChannels, dstAddress))
-                        throw new ArgumentException($"STBI could not load an image from the provided {nameof(data)}: {FailureReason()}");
+            fixed (byte* dstAddress = dst)
+                if (!LoadFromMemoryIntoBuffer(address, data.Length, desiredNumChannels, dstAddress))
+                    throw new ArgumentException($"STBI could not load an image from the provided {nameof(data)}: {FailureReason()}");
         }
 
         /// <summary>
@@ -204,6 +204,9 @@ namespace StbiSharp
         [DllImport("stbi")]
         unsafe public static extern byte* LoadFromMemory(byte* data, long len, out int width, out int height, out int numChannels, int desiredNumChannels);
 
+        [DllImport("stbi")]
+        unsafe public static extern void StbiSetFlipVerticallyOnLoad(bool flagTrueIfShouldFlip);
+
         /// <summary>
         /// Frees memory of an image that has previously been loaded by <see cref="LoadFromMemory"/>. Only
         /// has to be called when the byte-pointer overload of <see cref="LoadFromMemory"/> was used.
@@ -215,7 +218,7 @@ namespace StbiSharp
         /// <summary>
         /// After failure to load an image, returns a string describing the reason for the failure.
         /// </summary>
-        [DllImport("stbi", EntryPoint="FailureReason")]
+        [DllImport("stbi", EntryPoint = "FailureReason")]
         unsafe public static extern IntPtr FailureReasonIntPtr();
 
         /// <summary>
@@ -240,9 +243,11 @@ namespace StbiSharp
         /// been allocated to store the image data.</returns>
         unsafe public static StbiImage LoadFromMemory(ReadOnlySpan<byte> data, int desiredNumChannels)
         {
-            fixed (byte* address = data) {
+            fixed (byte* address = data)
+            {
                 byte* pixels = LoadFromMemory(address, data.Length, out int width, out int height, out int numChannels, desiredNumChannels);
-                if (pixels == null) {
+                if (pixels == null)
+                {
                     throw new ArgumentException($"STBI could not load an image from the provided {nameof(data)}: {FailureReason()}");
                 }
 
@@ -267,5 +272,7 @@ namespace StbiSharp
         /// been allocated to store the image data.</returns>
         public static StbiImage LoadFromMemory(MemoryStream data, int desiredNumChannels)
             => LoadFromMemory(data.GetBuffer(), desiredNumChannels);
+
+        public static void SetFlipVerticallyOnLoad(bool flagTrueIfShouldFlip) => StbiSetFlipVerticallyOnLoad(flagTrueIfShouldFlip);
     }
 }

--- a/stbi-sharp.cs
+++ b/stbi-sharp.cs
@@ -206,11 +206,10 @@ namespace StbiSharp
 
         /// <summary>
         /// Flip the image vertically, so the first pixel in the output array is the bottom left.
-
         /// </summary>
-        /// <param name="flagTrueIfShouldFlip">Flag set if should flip vertically on load.
+        /// <param name="shouldFlip">True if should flip vertically on load.</param>
         [DllImport("stbi")]
-        unsafe public static extern void SetFlipVerticallyOnLoad(bool flagTrueIfShouldFlip);
+        unsafe public static extern void SetFlipVerticallyOnLoad(bool shouldFlip);
 
         /// <summary>
         /// Frees memory of an image that has previously been loaded by <see cref="LoadFromMemory"/>. Only
@@ -221,7 +220,7 @@ namespace StbiSharp
         unsafe public static extern void Free(byte* data);
 
         /// <summary>
-        /// After failure to load an image, returns a string describing the reason for the failure.
+        /// After failure to load an image, returns a pointer to a string describing the reason for the failure.
         /// </summary>
         [DllImport("stbi", EntryPoint = "FailureReason")]
         unsafe public static extern IntPtr FailureReasonIntPtr();

--- a/stbi-sharp.csproj
+++ b/stbi-sharp.csproj
@@ -7,6 +7,7 @@
     <Description>A wrapper around stb_image.h</Description>
     <AssemblyTitle>STBI C# wrapper</AssemblyTitle>
     <AssemblyName>StbiSharp</AssemblyName>
+    <Version>1.0.1</Version>
   </PropertyGroup>
   <PropertyGroup Label="Nuget">
     <IsPackable>true</IsPackable>

--- a/stbi-sharp.csproj
+++ b/stbi-sharp.csproj
@@ -7,7 +7,6 @@
     <Description>A wrapper around stb_image.h</Description>
     <AssemblyTitle>STBI C# wrapper</AssemblyTitle>
     <AssemblyName>StbiSharp</AssemblyName>
-    <Version>1.0.1</Version>
   </PropertyGroup>
   <PropertyGroup Label="Nuget">
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
- Adds SetFlipVerticallyOnLoad method that wraps stbi_set_flip_vertically_on_load function from stb_image.h
  - Static function within Stbi class

Usage:
```c#
Stbi.SetFlipVerticallyOnLoad(true);
```